### PR TITLE
Add options to :session backend (fixes #1)

### DIFF
--- a/src/duct/middleware/buddy.clj
+++ b/src/duct/middleware/buddy.clj
@@ -5,7 +5,7 @@
 
 (def backends
   {:basic   backend/basic
-   :session (fn [_] (backend/session))
+   :session backend/session
    :token   backend/token
    :jws     backend/jws
    :jwe     backend/jwe})


### PR DESCRIPTION
Remove the wrapping `fn` to enable `backend/session` to accept configuration options